### PR TITLE
fix 'ConnectionNotFoundError' for CRUD operations on entities

### DIFF
--- a/packages/server/src/createTypeormConn.ts
+++ b/packages/server/src/createTypeormConn.ts
@@ -4,7 +4,8 @@ export const createTypeormConn = async () => {
   let retries = 5;
   while (retries) {
     try {
-      return createConnection(await getConnectionOptions(process.env.NODE_ENV));
+      const options = await getConnectionOptions(process.env.NODE_ENV);
+      return createConnection(await getConnectionOptions({...options, name: "default"}));
     } catch (err) {
       console.log(err);
       retries -= 1;


### PR DESCRIPTION
When invoking for example
`User.findOne()` or `User.create()` 
```
ConnectionNotFoundError: Connection "default" was not found.
```
is thrown.

This is because all entities are connected to the ormconfig.json's object called "default", unless `User.useConnection()` is used like:

```
  const connection = await createTypeormConn()
  User.useConnection(connection)
```

However, this becomes ugly with more and more entities added to the project.
The fix here just renames the imported "development" or "production" connection and renames it to "default" internally.

